### PR TITLE
fix: default to float64 if no example is given

### DIFF
--- a/schema2pyarrow/pyarrow_converter.py
+++ b/schema2pyarrow/pyarrow_converter.py
@@ -61,7 +61,7 @@ def map_datatypes(
     elif field_type == "number":
         if isinstance(field_example, int):
             return pa.int64()
-        if isinstance(field_example, float):
+        else:
             return pa.float64()
     elif field_type == "boolean":
         return pa.bool_()

--- a/tests/sample_schemas/complex_schema.yaml
+++ b/tests/sample_schemas/complex_schema.yaml
@@ -45,6 +45,7 @@ components:
                 description: Nested settings example
                 required:
                   - sampleInt
+                  - sampleFloatWithoutExample
                   - sampleTime
                 properties:
                   sampleInt:
@@ -54,6 +55,8 @@ components:
                     minimum: 0
                     maximum: 180
                     example: 7
+                  sampleFloatWithoutExample:
+                    type: number
                   sampleTime:
                     type: string
                     description: The time at which the event will be sent (uses 24h UTC format without time zone)

--- a/tests/sample_schemas/example_schemas.py
+++ b/tests/sample_schemas/example_schemas.py
@@ -23,6 +23,7 @@ complex_schema = [
                     pa.struct(
                         [
                             ("sampleInt", pa.int64()),
+                            ("sampleFloatWithoutExample", pa.float64()),
                             ("sampleTime", pa.string()),
                         ]
                     ),


### PR DESCRIPTION
<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->




## Description
<!-- Short description about the change, what have you done? -->
Closes #8 

if for a number no example is provided, the converter omits this field of type number. 
This fixes it by using float64 as default, fallback. 